### PR TITLE
This fixes 32bit builds on sparc.

### DIFF
--- a/jni/GNUmakefile
+++ b/jni/GNUmakefile
@@ -237,8 +237,11 @@ ifeq ($(CPU), i386)
   endif
 endif
 
+ifeq ($(CPU), sparcv9)
+  MODEL=64
+endif
 
-ifneq ($(findstring $(CPU), x86_64 amd64 sparcv9 ppc64 powerpc64 s390x),)
+ifneq ($(findstring $(CPU), x86_64 amd64 ppc64 powerpc64 s390x),)
   MODEL = 64
 endif
 


### PR DESCRIPTION
Since the 32bit architecture (sparc) is a substring of the 64 bit architecture (sparcv9).  Explictly check if we're on sparcv9 instead of doing a substring match.
