### PR TITLE
Remove native binaries from main jar

### DIFF
--- a/src/main/assembly/complete.xml
+++ b/src/main/assembly/complete.xml
@@ -12,17 +12,4 @@
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>
-  <fileSets>
-    <fileSet>
-      <directory>${project.build.directory}/jni</directory>
-      <outputDirectory>/jni</outputDirectory>
-      <includes>
-        <include>**/*.dll</include>
-        <include>**/*.so</include>
-        <include>**/*.jnilib</include>
-        <include>**/*.dylib</include>
-        <include>**/*.a</include>
-      </includes>
-    </fileSet>
-  </fileSets>
 </assembly>


### PR DESCRIPTION
When building jruby-complete, I noticed that it has transitive
dependencies on both the "main" jffi jar, and the "native" jffi
jar.  Prior to this commit, both jars contain a copy of the native
binaries, so one set is getting overwritten by the other set
during the construction of the final jruby-complete jar via
the shade plugin.

Raised the question as to whether this was intentional or not
in IRC #jruby, and it sounded like it was not.  This commit
would change the packaging so that the native binaries are only
packaged in the native jar, and give end users a bit more control
over what to include/exclude in downstream projects.
