### PR TITLE
Disable 'unused parameter' warning

### DIFF
--- a/jni/GNUmakefile
+++ b/jni/GNUmakefile
@@ -68,7 +68,7 @@ WERROR = -Werror
 ifneq ($(OS),darwin)
   WFLAGS += -Wundef $(WERROR)
 endif
-WFLAGS += -W -Wall -Wno-unused -Wno-parentheses
+WFLAGS += -W -Wall -Wno-unused -Wno-parentheses -Wno-unused-parameter
 PICFLAGS = -fPIC
 SOFLAGS = # Filled in for each OS specifically
 FFI_MMAP_EXEC = -DFFI_MMAP_EXEC_WRIT

--- a/libtest/GNUmakefile
+++ b/libtest/GNUmakefile
@@ -45,7 +45,7 @@ TEST_OBJS := $(patsubst $(SRC_DIR)/%.c, $(TEST_BUILD_DIR)/%.o, $(TEST_SRCS))
 #   http://weblogs.java.net/blog/kellyohair/archive/2006/01/compilation_of_1.html
 JFLAGS = -fno-omit-frame-pointer -fno-strict-aliasing
 OFLAGS = -O2 $(JFLAGS)
-WFLAGS = -W -Werror -Wall -Wno-unused -Wno-parentheses
+WFLAGS = -W -Werror -Wall -Wno-unused -Wno-parentheses -Wno-unused-parameter
 PICFLAGS = -fPIC
 SOFLAGS = -shared -Wl,-O1
 LDFLAGS += $(SOFLAGS)


### PR DESCRIPTION
Fixes tons of warnings turned into errors on Fedora 20:

  [exec] /home/penberg/jffi/jni/jffi/FastLongInvoke.c: In function ‘Java_com_kenai_jffi_Foreign_invokeL0’:
  [exec] /home/penberg/jffi/jni/jffi/FastLongInvoke.c:64:46: error: unused parameter ‘env’ [-Werror=unused-parameter]
  [exec]  Java_com_kenai_jffi_Foreign_invokeL0(JNIEnv\* env, jobject self, jlong ctxAddress, jlong function)
  [exec]                                               ^

Signed-off-by: Pekka Enberg penberg@iki.fi
