### PR TITLE
delete temporary library file after System.load

### DIFF
--- a/src/main/java/com/kenai/jffi/internal/StubLoader.java
+++ b/src/main/java/com/kenai/jffi/internal/StubLoader.java
@@ -355,6 +355,7 @@ public class StubLoader {
             os = null;
 
             System.load(dstFile.getAbsolutePath());
+            dstFile.delete();
         } catch (IOException ex) {
             throw new UnsatisfiedLinkError(ex.getMessage());
 


### PR DESCRIPTION
deleteOnExit does not work reliablely especially on windows. deleting
the file after it got loaded works (as far I tested it - can not test
on windows). so this a proposal to eventually fix https://github.com/jruby/jruby/issues/1237
