### PR TITLE
Add OSGi metadata for jffi and jffi native.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,51 @@
           <target>1.6</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.4.0</version>
+        <extensions>false</extensions>
+        <executions>
+          <execution>
+            <id>jffi-complete</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${project.build.directory}/META-INF-complete</manifestLocation>
+              <instructions>
+                <_nouses>true</_nouses>
+                <Import-Package><![CDATA[]]></Import-Package>
+                <Bundle-SymbolicName>com.github.jnr.jffi</Bundle-SymbolicName>
+                <Main-Class>com.kenai.jffi.Main</Main-Class>
+              </instructions>
+            </configuration>
+          </execution>
+          <!-- Alternate execution to generate the native JAR's manifest -->
+          <execution>
+            <id>native-assembly</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${project.build.directory}/META-INF-native</manifestLocation>
+              <instructions>
+                <_nouses>true</_nouses>
+                <Import-Package><![CDATA[]]></Import-Package>
+                <Export-Package><![CDATA[]]></Export-Package>
+                <Fragment-Host>com.github.jnr.jffi</Fragment-Host>
+                <Bundle-ClassPath>.,jni</Bundle-ClassPath>
+                <Bundle-Description>Java Foreign Function Interface - Native Libraries</Bundle-Description>
+                <Bundle-SymbolicName>com.github.jnr.jffi.native</Bundle-SymbolicName>
+                <Require-Bundle>com.github.jnr.jffi</Require-Bundle>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 <!--
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
@@ -187,10 +232,7 @@
               </descriptors>
               <archive>
                 <index>true</index>
-                <manifest>
-                  <addClasspath>true</addClasspath>
-                  <mainClass>com.kenai.jffi.Main</mainClass>
-                </manifest>
+                <manifestFile>${project.build.directory}/META-INF-complete/MANIFEST.MF</manifestFile>
               </archive>
               <appendAssemblyId>false</appendAssemblyId>
             </configuration>
@@ -207,9 +249,7 @@
               </descriptors>
               <archive>
                 <index>true</index>
-                <manifest>
-                  <addClasspath>true</addClasspath>
-                </manifest>
+                <manifestFile>${project.build.directory}/META-INF-native/MANIFEST.MF</manifestFile>
               </archive>
             </configuration>
           </execution>


### PR DESCRIPTION
Use maven-bundle-plugin to generate OSGi metadata and include it in the jar manifest.  This does not impact the existing behavior of the jffi jar being an executable jar calling com.kenai.jffi.Main.

Inspired by the manifests from the jffi-native RPM.  This adds metadata for both jffi and jffi-native jar.  jffi-native is treated as a fragment of jffi.

Example manifests:

jffi:
```
Manifest-Version: 1.0
Bnd-LastModified: 1457061432285
Build-Jdk: 1.8.0_60
Built-By: atolbert
Bundle-Description: Java Foreign Function Interface
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion: 2
Bundle-Name: jffi
Bundle-SymbolicName: com.github.jnr.jffi
Bundle-Version: 1.2.11
Created-By: Apache Maven Bundle Plugin
Export-Package: com.kenai.jffi;version="1.2.11"
Main-Class: com.kenai.jffi.Main
Tool: Bnd-2.1.0.20130426-122213
```

jffi-native:
```
Manifest-Version: 1.0
Bnd-LastModified: 1457061432630
Build-Jdk: 1.8.0_60
Built-By: atolbert
Bundle-ClassPath: .,jni
Bundle-Description: Java Foreign Function Interface - Native Libraries
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion: 2
Bundle-Name: jffi
Bundle-SymbolicName: com.github.jnr.jffi.native
Bundle-Version: 1.2.11
Created-By: Apache Maven Bundle Plugin
Fragment-Host: com.github.jnr.jffi
Require-Bundle: com.github.jnr.jffi
Tool: Bnd-2.1.0.20130426-122213
```


Prior manifests:

jffi:
```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Created-By: Apache Maven
Built-By: atolbert
Build-Jdk: 1.8.0_60
Main-Class: com.kenai.jffi.Main
```

jffi-native:
```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Created-By: Apache Maven
Built-By: atolbert
Build-Jdk: 1.8.0_60
```
