### PR TITLE
Fix broken evaluation of CCACHE makefile variable

### DIFF
--- a/jni/GNUmakefile
+++ b/jni/GNUmakefile
@@ -32,7 +32,7 @@ JNIEXT = so
 
 export MACOSX_DEPLOYMENT_TARGET=10.4
 
-CCACHE := $(strip $(realpath $(shell which ccache 2> /dev/null)))
+CCACHE := $(ccache -V >/dev/null 2>&1 && echo ccache)
 SRC_DIR ?= $(shell pwd)/jni
 JNI_DIR ?= $(SRC_DIR)
 BUILD_DIR ?= $(shell pwd)/build

--- a/libtest/GNUmakefile
+++ b/libtest/GNUmakefile
@@ -35,7 +35,7 @@ LIBNAME = $(PREFIX)test.$(LIBEXT)
 
 export MACOSX_DEPLOYMENT_TARGET=10.4
 
-CCACHE := $(strip $(realpath $(shell which ccache 2> /dev/null)))
+CCACHE := $(ccache -V >/dev/null 2>&1 && echo ccache)
 
 TEST_SRCS = $(wildcard $(SRC_DIR)/*.c)
 TEST_OBJS := $(patsubst $(SRC_DIR)/%.c, $(TEST_BUILD_DIR)/%.o, $(TEST_SRCS))


### PR DESCRIPTION
On my Solaris 11 test system it just so happens that no ccache is installed.
The existing method of determinig that (using **which** and assume that it prints the path on stdout **only if** the executable was found) does not work using the default variant of **which** on solaris: It prints **on stdout** something like
```no ccache in /opt/csw/java/jdk/jdk7/bin /opt/csw/bin /usr/bin /usr/sbin```.
This gets taken as CCACHE and subsequently fails the build.
Given that the absolute path is not required anyway, my fix lets the shell do the search itself and relies on a zero exit code if ccache is invoked with some harmless parameter (-V in this case).