### PR TITLE
Avoid undefined behaviour of LoadLibrary() on Windows.

### DIFF
--- a/jni/jffi/Library.c
+++ b/jni/jffi/Library.c
@@ -86,8 +86,10 @@ Java_com_kenai_jffi_Foreign_dlopen(JNIEnv* env, jobject self, jstring jPath, jin
         return p2j(GetModuleHandle(NULL));
     } else {
         wchar_t path[PATH_MAX];
+        DWORD dwFlags;
         getWideString(env, path, jPath, sizeof(path) / sizeof(path[0]));
-        return p2j(LoadLibraryExW(path, NULL, LOAD_WITH_ALTERED_SEARCH_PATH));
+        dwFlags = PathIsRelativeW(path) ? 0 : LOAD_WITH_ALTERED_SEARCH_PATH;
+        return p2j(LoadLibraryExW(path, NULL, dwFlags));
     }
 #else
     char path_[PATH_MAX];
@@ -173,7 +175,8 @@ dl_open(const char* name, int flags)
     if (name == NULL) {
         return GetModuleHandle(NULL);
     } else {
-        return LoadLibraryEx(name, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+        DWORD dwFlags = PathIsRelative(name) ? 0 : LOAD_WITH_ALTERED_SEARCH_PATH;
+        return LoadLibraryEx(name, NULL, dwFlags);
     }
 }
 


### PR DESCRIPTION
According to [1] the flag LOAD_WITH_ALTERED_SEARCH_PATH should be used with absolute paths only. It has the effect, that the path of the DLL to be loaded is temporary added to the search path, so that dependent DLLs in the same directory can be found and loaded implicit.

However for relative paths the standard LoadLibrary() search order should be used, because the behaviour of LOAD_WITH_ALTERED_SEARCH_PATH isn't defined for relative paths. In practice (on Windows 10) relative paths to Windows system DLLs do work, so that the library is loaded,
but DLLs in other search paths are not found, when this flag is set.

[1] https://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx