### PR TITLE
If a temp file cannot be created, report that as a separate error message (not just UnsatisfiedLinkError)

### DIFF
--- a/src/main/java/com/kenai/jffi/Type.java
+++ b/src/main/java/com/kenai/jffi/Type.java
@@ -249,7 +249,7 @@ public abstract class Type {
 
             } catch (Throwable error) {
                 UnsatisfiedLinkError ule = new UnsatisfiedLinkError("could not get native definition for type: " + nativeType);
-                error.initCause(error);
+                ule.initCause(error);
                 throw ule;
             }
         }

--- a/src/main/java/com/kenai/jffi/internal/StubLoader.java
+++ b/src/main/java/com/kenai/jffi/internal/StubLoader.java
@@ -355,8 +355,13 @@ public class StubLoader {
         InputStream is = getStubLibraryStream();
         FileOutputStream os = null;
 
+        File dstFile;
         try {
-            File dstFile = File.createTempFile("jffi", "." + dlExtension());
+            dstFile = File.createTempFile("jffi", "." + dlExtension());
+        } catch (IOException ex) {
+            throw new IOException("Failed to create temporary file: jffiXXX." + dlExtension());
+        }
+        try {
             dstFile.deleteOnExit();
             os = new FileOutputStream(dstFile);
             ReadableByteChannel srcChannel = Channels.newChannel(is);


### PR DESCRIPTION
This cost me a few hours, in the hope it won't for the next guy.