### PR TITLE
Preliminary support for DragonFly BSD

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -127,6 +127,7 @@
       <or>
         <os name="FreeBSD"/>
         <os name="OpenBSD"/>
+        <os name="DragonFlyBSD"/>
         <os name="AIX"/>
         <os name="HP-UX"/>
       </or>

--- a/jni/GNUmakefile
+++ b/jni/GNUmakefile
@@ -229,6 +229,10 @@ ifeq ($(OS), aix)
   STRIP = strip
 endif
 
+ifneq ($(OS), dragonflybsd)
+  SOFLAGS = -shared
+endif
+
 ifneq ($(findstring bsd, $(OS)),)
   SOFLAGS = -shared -static-libgcc
   CFLAGS += -pthread

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,15 @@
               <make.exe>gmake</make.exe>
           </properties>
       </profile>
+      <profile>
+        <id>dragonfly-profile</id>
+        <activation>
+          <os><name>dragonflybsd</name></os>
+        </activation>
+        <properties>
+          <make.exe>gmake</make.exe>
+        </properties>
+      </profile>
   </profiles>
 
   <build>

--- a/src/main/java/com/kenai/jffi/Platform.java
+++ b/src/main/java/com/kenai/jffi/Platform.java
@@ -55,6 +55,8 @@ public abstract class Platform {
         NETBSD,
         /** OpenBSD */
         OPENBSD,
+	/** DragonFly */
+	DRAGONFLY,
         /** Linux */
         LINUX,
         /** Solaris (and OpenSolaris) */
@@ -145,7 +147,10 @@ public abstract class Platform {
         
         } else if (startsWithIgnoreCase(osName, "freebsd")) {
             return OS.FREEBSD;
-        
+
+        } else if (startsWithIgnoreCase(osName, "dragonfly")) {
+            return OS.DRAGONFLY;
+
         } else if (startsWithIgnoreCase(osName, "windows")) {
             return OS.WINDOWS;
         

--- a/src/main/java/com/kenai/jffi/internal/StubLoader.java
+++ b/src/main/java/com/kenai/jffi/internal/StubLoader.java
@@ -77,6 +77,8 @@ public class StubLoader {
         NETBSD,
         /** OpenBSD */
         OPENBSD,
+	/** DragonFly */
+	DRAGONFLY,
         /** Linux */
         LINUX,
         /** Solaris (and OpenSolaris) */
@@ -148,6 +150,8 @@ public class StubLoader {
             return OS.OPENBSD;
         } else if (Util.startsWithIgnoreCase(osName, "freebsd", LOCALE)) {
             return OS.FREEBSD;
+	} else if (Util.startsWithIgnoreCase(osName, "dragonfly", LOCALE)) {
+            return OS.DRAGONFLY;
         } else if (Util.startsWithIgnoreCase(osName, "windows", LOCALE)) {
             return OS.WINDOWS;
         } else {


### PR DESCRIPTION
This is the preliminary support for DragonFly BSD.

I've added a specific conditional for it in the GNUMakefile so that the '-shared- flag is passed during link time, not sure if that's 100% correct.

In any case jffi has been tested with jnr-posix via jruby and it seems to work, at least for FileStat:

    $ uname -a
    DragonFly brix.sector.int 5.5-DEVELOPMENT DragonFly v5.5.0.56.g5c117-DEVELOPMENT #2: Wed Dec 12 18:54:56 CET 2018     antonioh@localhost:/usr/obj/home/antonioh/s/dragonfly/sys/X86_64_GENERIC  x86_64
    $ stat /tmp/vagrant.log
    117505793 3843062 -rw-r--r-- 1 antonioh wheel 4294967295 88814 "Nov  6 20:56:15 2018" "Nov  6 20:56:15 2018" "Nov  6 20:54:53 2018" 65536 48 0 /tmp/vagrant.log
    $ ./bin/jruby -e 'print File::Stat.new("/tmp/vagrant.log").inspect'
    #<File::Stat dev=0x700ff01, ino=3843062, mode=0100644, nlink=1, uid=1000, gid=0, rdev=0xffffffff, size=88814, blksize=48, blocks=0, atime=2018-11-06 19:56:15 +0000, mtime=2018-11-06 19:56:15 +0000, ctime=2018-11-06 19:54:53 +0000, birthtime=2018-11-06 19:56:15 +0000>

Let me know if I have to fix anything. I'll be sending the rest of PRs for DragonFly BSD.
