### PR TITLE
Make the regression test suite stricter

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -176,6 +176,7 @@
     <mkdir dir="${build.test.dir}/results"/>
     <junit fork="${test.fork}" forkMode="${test.fork.mode}" printsummary="withOutAndErr" haltonfailure="true">
       <jvmarg value="${run.jvm.model}"/>
+      <env key="LC_ALL" value="C"/>
       <classpath>
         <pathelement location="${build.classes.dir}"/>
         <pathelement location="${build.test.dir}/classes"/>

--- a/build.xml
+++ b/build.xml
@@ -174,7 +174,7 @@
 
   <target name="test" depends="compile,-compile-test">
     <mkdir dir="${build.test.dir}/results"/>
-    <junit fork="${test.fork}" forkMode="${test.fork.mode}" printsummary="withOutAndErr" haltonfailure="false">
+    <junit fork="${test.fork}" forkMode="${test.fork.mode}" printsummary="withOutAndErr" haltonfailure="true">
       <jvmarg value="${run.jvm.model}"/>
       <classpath>
         <pathelement location="${build.classes.dir}"/>

--- a/src/test/java/com/kenai/jffi/UnitHelper.java
+++ b/src/test/java/com/kenai/jffi/UnitHelper.java
@@ -61,6 +61,8 @@ public class UnitHelper {
                 return "libc.so.6";
             case DARWIN:
                 return "libc.dylib";
+            case FREEBSD:
+                return "libc.so.7";
             case WINDOWS:
                 return "msvcrt.dll";
             case AIX:


### PR DESCRIPTION
The build succeeds when the test suite fails, which surprised me a lot while working on the library and hit me again recently.

Make the build fail when the regression test suite does not pass.  This helped fixing getting the right libc.so name on FreeBSD and detecting that the user's environment variables may have an impact on the library.