### PR TITLE
Add support for compilation on Java 10.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -297,11 +297,13 @@
   <target name="-generate-native-headers" depends="-init-vars,-generate-version,-compile-java">
     <mkdir dir="${build.native.dir}"/>
     <mkdir dir="${build.classes.dir}"/>
-    <javah classpath="${build.classes.dir}" destdir="${build.native.dir}" force="yes">
-      <class name="com.kenai.jffi.Foreign"/>
-      <class name="com.kenai.jffi.ObjectBuffer"/>
-      <class name="com.kenai.jffi.Version"/>
-    </javah>
+    <javac destdir="${build.native.dir}" nativeheaderdir="${build.native.dir}">
+      <src path="${src.dir}"/>
+      <src path="${build.dir}/java"/>
+      <include name="com/kenai/jffi/Foreign.java"/>
+      <include name="com/kenai/jffi/ObjectBuffer.java"/>
+      <include name="com/kenai/jffi/Version.java"/>
+    </javac>
     <!--
     <exec executable="javah" failonerror="true">
       <arg line="-d ${build.native.dir}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     <maven.test.skip>true</maven.test.skip>
     <maven.test.failure.ignore>true</maven.test.failure.ignore>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <make.exe>make</make.exe>
   </properties>
 
@@ -89,7 +89,6 @@
         <configuration>
           <debug>true</debug>
           <showDeprecation>true</showDeprecation>
-          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/kenai/jffi/Foreign.java
+++ b/src/main/java/com/kenai/jffi/Foreign.java
@@ -34,6 +34,7 @@
  * Interface to  the foreign function interface.
  */
 package com.kenai.jffi;
+import java.lang.annotation.Native;
 
 import java.lang.reflect.Method;
 import java.nio.Buffer;
@@ -113,94 +114,153 @@ final class Foreign {
             throw new RuntimeException(t);
         }
     }
+    @Native
     public final static int VERSION_MAJOR = getVersionField("MAJOR");
+    @Native
     public final static int VERSION_MINOR = getVersionField("MINOR");
+    @Native
     public final static int VERSION_MICRO = getVersionField("MICRO");
 
+    @Native
     public final static int TYPE_VOID = 0;
+    @Native
     public final static int TYPE_FLOAT = 2;
+    @Native
     public final static int TYPE_DOUBLE = 3;
+    @Native
     public final static int TYPE_LONGDOUBLE = 4;
+    @Native
     public final static int TYPE_UINT8 = 5;
+    @Native
     public final static int TYPE_SINT8 = 6;
+    @Native
     public final static int TYPE_UINT16 = 7;
+    @Native
     public final static int TYPE_SINT16 = 8;
+    @Native
     public final static int TYPE_UINT32 = 9;
+    @Native
     public final static int TYPE_SINT32 = 10;
+    @Native
     public final static int TYPE_UINT64 = 11;
+    @Native
     public final static int TYPE_SINT64 = 12;
+    @Native
     public final static int TYPE_STRUCT = 13;
+    @Native
     public final static int TYPE_POINTER = 14;
 
+    @Native
     public final static int TYPE_UCHAR = 101;
+    @Native
     public final static int TYPE_SCHAR = 102;
+    @Native
     public final static int TYPE_USHORT = 103;
+    @Native
     public final static int TYPE_SSHORT = 104;
+    @Native
     public final static int TYPE_UINT = 105;
+    @Native
     public final static int TYPE_SINT = 106;
+    @Native
     public final static int TYPE_ULONG = 107;
+    @Native
     public final static int TYPE_SLONG = 108;
 
     /** Perform  lazy  binding. Only resolve symbols as needed */
+    @Native
     public static final int RTLD_LAZY   = 0x00001;
 
     /** Resolve all symbols when loading the library */
+    @Native
     public static final int RTLD_NOW    = 0x00002;
 
     /** Symbols in this library are not made available to other libraries */
+    @Native
     public static final int RTLD_LOCAL  = 0x00004;
 
     /** All symbols in the library are made available to other libraries */
+    @Native
     public static final int RTLD_GLOBAL = 0x00008;
 
     /** Pages can be read */
+    @Native
     public static final int PROT_READ  = 0x1;
 
     /** Pages can be written */
+    @Native
     public static final int PROT_WRITE = 0x2;
 
     /** Pages can be executed */
+    @Native
     public static final int PROT_EXEC  = 0x4;
 
     /** Pages cannot be accessed */
+    @Native
     public static final int PROT_NONE  = 0x0;
 
     /** Share changes */
+    @Native
     public static final int MAP_SHARED = 0x1;
 
+    @Native
     public static final int MAP_PRIVATE = 0x2;
 
     /** Use the specified address */
+    @Native
     public static final int MAP_FIXED = 0x10;
 
+    @Native
     public static final int MAP_NORESERVE = 0x40;
 
+    @Native
     public static final int MAP_ANON = 0x100;
 
+    @Native
     public static final int MAP_ALIGN = 0x200;
 
     /** Code segment memory */
+    @Native
     public static final int MAP_TEXT = 0x400;
 
     /** Win32 VirtualAlloc/VirtualProtect flags */
+    @Native
     public static final int PAGE_NOACCESS = 0x0001;
+    @Native
     public static final int PAGE_READONLY = 0x0002;
+    @Native
     public static final int PAGE_READWRITE = 0x0004;
+    @Native
     public static final int PAGE_WRITECOPY = 0x0008;
+    @Native
     public static final int PAGE_EXECUTE           = 0x0010;
+    @Native
     public static final int PAGE_EXECUTE_READ      = 0x0020;
+    @Native
     public static final int PAGE_EXECUTE_READWRITE = 0x0040;
+    @Native
     public static final int PAGE_EXECUTE_WRITECOPY = 0x0080;
+    @Native
     public static final int MEM_COMMIT    =      0x1000;
+    @Native
     public static final int MEM_RESERVE   =      0x2000;
+    @Native
     public static final int MEM_DECOMMIT  =      0x4000;
+    @Native
     public static final int MEM_RELEASE   =      0x8000;
+    @Native
     public static final int MEM_FREE      =     0x10000;
+    @Native
     public static final int MEM_PRIVATE   =     0x20000;
+    @Native
     public static final int MEM_MAPPED    =     0x40000;
+    @Native
     public static final int MEM_RESET     =     0x80000;
+    @Native
     public static final int MEM_TOP_DOWN  =    0x100000;
+    @Native
     public static final int MEM_PHYSICAL  =    0x400000;
+    @Native
     public static final int MEM_4MB_PAGES =  0x80000000;
 
     /*
@@ -221,21 +281,25 @@ final class Foreign {
     /**
      * Default calling convention
      */
+    @Native
     public static final int F_DEFAULT = 0x0;
 
     /**
      * Windows STDCALL calling convention
      */
+    @Native
     public static final int F_STDCALL = 0x1;
 
     /**
      * Do not save errno after each call
      */
+    @Native
     public static final int F_NOERRNO = 0x2;
 
     /**
      * Try to capture segmentation faults and convert to java exceptions
      */
+    @Native
     public static final int F_PROTECT = 0x4;
 
     /**

--- a/src/main/java/com/kenai/jffi/ObjectBuffer.java
+++ b/src/main/java/com/kenai/jffi/ObjectBuffer.java
@@ -31,55 +31,87 @@
  */
 
 package com.kenai.jffi;
+import java.lang.annotation.Native;
 
 /**
  * Holds objects the native code must handle - such as primitive arrays
  */
 final class ObjectBuffer {
     /** Copy the array contents to native memory before calling the function */
+    @Native
     public static final int IN = 0x1;
 
     /** After calling the function, reload the array contents from native memory */
+    @Native
     public static final int OUT = 0x2;
 
     /** Append a NUL byte to the array contents after copying to native memory */
+    @Native
     public static final int ZERO_TERMINATE = 0x4;
 
-    /** Pin the array memory and pass the JVM memory pointer directly to the function */
+    /**
+     * Pin the array memory and pass the JVM memory pointer directly to the function
+     */
+    @Native
     public static final int PINNED = 0x8;
 
     /** For OUT arrays, clear the temporary native memory area */
+    @Native
     public static final int CLEAR = 0x10;
 
     /*
-     * WARNING: The following flags cannot be altered without recompiling the native code 
+     * WARNING: The following flags cannot be altered without recompiling the native
+     * code
      */
+    @Native
     static final int INDEX_SHIFT = 16;
+    @Native
     static final int INDEX_MASK = 0x00ff0000;
+    @Native
     static final int TYPE_SHIFT = 24;
+    @Native
     static final int TYPE_MASK = 0xff << TYPE_SHIFT;
+    @Native
     static final int PRIM_MASK = 0x0f << TYPE_SHIFT;
+    @Native
     static final int FLAGS_SHIFT = 0;
+    @Native
     static final int FLAGS_MASK = 0xff;
 
+    @Native
     static final int ARRAY = 0x10 << TYPE_SHIFT;
+    @Native
     static final int BUFFER = 0x20 << TYPE_SHIFT;
+    @Native
     static final int JNI = 0x40 << TYPE_SHIFT;
-    
+
+    @Native
     static final int BYTE = 0x1 << TYPE_SHIFT;
+    @Native
     static final int SHORT = 0x2 << TYPE_SHIFT;
+    @Native
     static final int INT = 0x3 << TYPE_SHIFT;
+    @Native
     static final int LONG = 0x4 << TYPE_SHIFT;
+    @Native
     static final int FLOAT = 0x5 << TYPE_SHIFT;
+    @Native
     static final int DOUBLE = 0x6 << TYPE_SHIFT;
+    @Native
     static final int BOOLEAN = 0x7 << TYPE_SHIFT;
+    @Native
     static final int CHAR = 0x8 << TYPE_SHIFT;
 
-    /* NOTE: The JNI types can overlap the primitive type, since they are mutually exclusive */
+    /*
+     * NOTE: The JNI types can overlap the primitive type, since they are mutually
+     * exclusive
+     */
     /** The JNIEnv address */
+    @Native
     public static final int JNIENV = 0x1 << TYPE_SHIFT;
 
     /** The jobject handle */
+    @Native
     public static final int JNIOBJECT = 0x2 << TYPE_SHIFT;
 
     /** The objects stored in this buffer */

--- a/version.xml
+++ b/version.xml
@@ -8,10 +8,14 @@
         <mkdir dir="${build.dir}/java/com/kenai/jffi"/>
         <echo file="${build.dir}/java/com/kenai/jffi/Version.java" append="false">
             package com.kenai.jffi;
+            import java.lang.annotation.Native;
             public final class Version {
                 private Version() {}
+                @Native
                 public static final int MAJOR = ${jffi.version.major};
+                @Native
                 public static final int MINOR = ${jffi.version.minor};
+                @Native
                 public static final int MICRO = ${jffi.version.micro};
             }
         </echo>


### PR DESCRIPTION
- Fixes #55
- Change javah to javac in ant task
- Add @Native annotation to static fields
- Set source/target to 1.8 for maven-compiler-plugin as 1.6 not supported
- Remove redundant <target> definition from maven-compiler-plugin

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>