### PR TITLE
Update apt to get newer ant version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: java
+before_install:
+  - wget --no-check-certificate https://www.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.tar.gz
+  - tar -xzvf apache-ant-1.10.8-bin.tar.gz
+  - export PATH=`pwd`/apache-ant-1.10.8/bin:$PATH
+  - echo $(ant -version)
 addons:
   apt:
     sources:


### PR DESCRIPTION
Trying to get ahead of changes in #84 which require an update ant `javac` task.