### PR TITLE
Add workflow to build native library with qemu & docker

### DIFF
--- a/.github/build-native-debian.sh
+++ b/.github/build-native-debian.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+cd "$(dirname "$(dirname "$0")")"
+
+apt-get update -y
+apt-get install -y --no-install-recommends openjdk-8-jdk-headless ant make gcc libc6-dev
+rm archive/*
+ant jar && ant archive-platform-jar
+

--- a/.github/experimental-docker.json
+++ b/.github/experimental-docker.json
@@ -1,0 +1,4 @@
+{
+  "cgroup-parent": "/actions_job",
+  "experimental": true
+}

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,0 +1,40 @@
+# This workflow will build the native component for different platforms using
+# qemu-user & docker
+
+name: Build Native
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  arm64:
+
+    # Switch back to ubuntu-latest after that maps to 20.04
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install qemu
+        run: sudo apt-get install -y --no-install-recommends qemu-user-static
+      - name: Experimental Docker
+        run: sudo cp .github/experimental-docker.json /etc/docker/daemon.json
+      - name: Restart Docker
+        run: sudo systemctl restart docker.service
+      - name: Clean old docker image
+        run: docker rmi debian:9 || true
+      - name: Build inside Docker
+        run: docker run --rm --platform arm64 -v $GITHUB_WORKSPACE:/work debian:9 /work/.github/build-native-debian.sh
+      - name: Archive built library
+        uses: actions/upload-artifact@v2
+        with:
+          name: shared-object
+          path: build/jni/*.so
+      - name: Archive built jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: jar
+          path: archive/*.jar
+


### PR DESCRIPTION
Initial stab at providing a GitHub action to build the native libraries with qemu & docker (see #69).

This is my first GitHub Action, so it can probably be improved :smile:

Docker's multi-platform support is kinda iffy: It took me quite a while to realize I got the wrong image on `docker run`, because an already existing image was used and docker doesn't realize that had the wrong platform...

I did a quick check and this method will probably work for
- `arm64` aka. `linux/arm64/v8` (Debian: `arm64`)
- `arm` aka. `linux/arm/v7` (Debian: `armhf`)
- `linux/arm/v5` (Debian: `armel`)
- `386` aka. `linux/386` (Debian: `i386`)

Those are all platforms available for the `debian:9` image. `debian:10` would additionally give us:
- `s390x` (Debian: `s390x`)
- `mips64le` (Debian: `mips64el`)
- `ppc64le` (Debian: `ppc64el`)

But then you have to jump through some hoops to get Java 8 :roll_eyes: 

All of those start under qemu-user, I only tried builds with the `arm64` one...