### PR TITLE
Use distinct Automatic-Module-Name for native jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                 <Bundle-Description>Java Foreign Function Interface - Native Libraries</Bundle-Description>
                 <Bundle-SymbolicName>com.github.jnr.jffi.native</Bundle-SymbolicName>
                 <Require-Bundle>com.github.jnr.jffi</Require-Bundle>
-                <Automatic-Module-Name>org.jnrproject.jffi.syslibs</Automatic-Module-Name>
+                <Automatic-Module-Name>org.jnrproject.jffi.nativelibs</Automatic-Module-Name>
 
               </instructions>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -135,17 +135,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>org.jnrproject.jffi</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>2.4.0</version>
@@ -164,6 +153,7 @@
                 <Import-Package />
                 <Bundle-SymbolicName>com.github.jnr.jffi</Bundle-SymbolicName>
                 <Main-Class>com.kenai.jffi.Main</Main-Class>
+                <Automatic-Module-Name>org.jnrproject.jffi</Automatic-Module-Name>
               </instructions>
             </configuration>
           </execution>
@@ -185,6 +175,8 @@
                 <Bundle-Description>Java Foreign Function Interface - Native Libraries</Bundle-Description>
                 <Bundle-SymbolicName>com.github.jnr.jffi.native</Bundle-SymbolicName>
                 <Require-Bundle>com.github.jnr.jffi</Require-Bundle>
+                <Automatic-Module-Name>org.jnrproject.jffi.syslibs</Automatic-Module-Name>
+
               </instructions>
             </configuration>
           </execution>


### PR DESCRIPTION
Fixes #67 

We've been experiencing the same issue as the reporter. The extent of my testing has been building and using the jars  and using them as our project dependencies works, i haven't tested beyond this. 

It would be nice if this could be back patched for previous releases. 

