### PR TITLE
Update system before installing qemu

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Update System
+        run: sudo apt-get update -y
       - name: Install qemu
         run: sudo apt-get install -y --no-install-recommends qemu-user-static
       - name: Experimental Docker


### PR DESCRIPTION
This is necessary to get a current qemu package instead of a download error... :roll_eyes: 