### PR TITLE
Add multiple native build workflows

### DIFF
--- a/.github/build-native-debian.sh
+++ b/.github/build-native-debian.sh
@@ -4,8 +4,16 @@ set -ex
 
 cd "$(dirname "$(dirname "$0")")"
 
+# Add stretch for Java 8
+cat <<END > /etc/apt/sources.list.d/stretch.list
+deb http://deb.debian.org/debian stretch main
+deb http://security.debian.org/debian-security stretch/updates main
+END
+
 apt-get update -y
-apt-get install -y --no-install-recommends openjdk-8-jdk-headless ant make gcc libc6-dev texinfo
+apt-get install -y --no-install-recommends openjdk-8-jdk-headless make gcc libc6-dev texinfo
+# Needs to be split, otherwise a newer version of OpenJDK is pulled
+apt-get install -y --no-install-recommends ant
 rm archive/*
 ant jar && ant archive-platform-jar
 

--- a/.github/build-native-debian.sh
+++ b/.github/build-native-debian.sh
@@ -5,7 +5,7 @@ set -ex
 cd "$(dirname "$(dirname "$0")")"
 
 apt-get update -y
-apt-get install -y --no-install-recommends openjdk-8-jdk-headless ant make gcc libc6-dev
+apt-get install -y --no-install-recommends openjdk-8-jdk-headless ant make gcc libc6-dev texinfo
 rm archive/*
 ant jar && ant archive-platform-jar
 

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -10,10 +10,20 @@ on:
     branches: [ master ]
 
 jobs:
-  arm64:
+  native:
 
     # Switch back to ubuntu-latest after that maps to 20.04
     runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        arch:
+          - "386"
+          - amd64
+          - arm
+          - arm64
+          - linux-arm-v5
+          - s390x
 
     steps:
       - uses: actions/checkout@v2
@@ -28,15 +38,15 @@ jobs:
       - name: Clean old docker image
         run: docker rmi debian:9 || true
       - name: Build inside Docker
-        run: docker run --rm --platform arm64 -v $GITHUB_WORKSPACE:/work debian:9 /work/.github/build-native-debian.sh
+        run: docker run --rm --platform $(echo ${{ matrix.arch }} | sed 's|-|/|g') -v $GITHUB_WORKSPACE:/work debian:9 /work/.github/build-native-debian.sh
       - name: Archive built library
         uses: actions/upload-artifact@v2
         with:
-          name: shared-object
+          name: shared-object-${{ matrix.arch }}
           path: build/jni/*.so
       - name: Archive built jar
         uses: actions/upload-artifact@v2
         with:
-          name: jar
+          name: jar-${{ matrix.arch }}
           path: archive/*.jar
 

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -35,10 +35,10 @@ jobs:
         run: sudo cp .github/experimental-docker.json /etc/docker/daemon.json
       - name: Restart Docker
         run: sudo systemctl restart docker.service
-      - name: Clean old docker image
-        run: docker rmi debian:9 || true
+      - name: Pull docker image
+        run: docker pull --platform $(echo ${{ matrix.arch }} | sed 's|-|/|g') debian:10 || true
       - name: Build inside Docker
-        run: docker run --rm --platform $(echo ${{ matrix.arch }} | sed 's|-|/|g') -v $GITHUB_WORKSPACE:/work debian:9 /work/.github/build-native-debian.sh
+        run: docker run --rm -v $GITHUB_WORKSPACE:/work debian:10 /work/.github/build-native-debian.sh
       - name: Archive built library
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
As written in #90, we can use the qemu-with-docker trick with every platform supported by the OCI specification. I played around with it a bit and this adds all platforms which work out-of-the-box:

- 386 (aka. i386, x86_32)
- amd64
- arm (armv7, armhf)
- arm64 (armv8, aarch64)
- linux-arm-v5 (armel)
- s390x

I tried to add mips64le and ppc64le, both those seem to be broken on a very low level (ppc64le runs into qemu problems, mips64le has trouble running ant..)