### PR TITLE
Add jffi.extract.name for specific file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -161,6 +161,8 @@
 
   <target name="test" depends="compile,-compile-test">
     <mkdir dir="${build.test.dir}/results"/>
+
+    <echo>test with jni libraries from sources</echo>
     <junit fork="${test.fork}" forkMode="${test.fork.mode}" printsummary="withOutAndErr" haltonfailure="true">
       <env key="LC_ALL" value="C"/>
       <classpath>
@@ -177,7 +179,45 @@
           <include name="**/*Test*.java"/>
         </fileset>
       </batchtest>
+    </junit>
 
+    <echo>test with unpack of jni library</echo>
+    <junit fork="${test.fork}" forkMode="${test.fork.mode}" printsummary="withOutAndErr" haltonfailure="true">
+      <env key="LC_ALL" value="C"/>
+      <classpath>
+        <pathelement location="${build.classes.dir}"/>
+        <pathelement location="${build.test.dir}/classes"/>
+        <fileset dir="archive" includes="*.jar"/>
+        <pathelement location="lib/junit_4/junit-4.11.jar"/>
+        <pathelement location="lib/junit_4/hamcrest-core-1.3.jar"/>
+      </classpath>
+
+      <formatter type="plain" /> <!-- to file -->
+      <batchtest todir="${build.test.dir}/results">
+        <fileset dir="${src.test.dir}">
+          <include name="**/*Test*.java"/>
+        </fileset>
+      </batchtest>
+    </junit>
+
+    <echo>test with unpack of jni library to specific locatiohn</echo>
+    <junit fork="${test.fork}" forkMode="${test.fork.mode}" printsummary="withOutAndErr" haltonfailure="true">
+      <env key="LC_ALL" value="C"/>
+      <classpath>
+        <pathelement location="${build.classes.dir}"/>
+        <pathelement location="${build.test.dir}/classes"/>
+        <fileset dir="archive" includes="*.jar"/>
+        <pathelement location="lib/junit_4/junit-4.11.jar"/>
+        <pathelement location="lib/junit_4/hamcrest-core-1.3.jar"/>
+      </classpath>
+      <sysproperty key="jffi.extract.name" value=""/>
+
+      <formatter type="plain" /> <!-- to file -->
+      <batchtest todir="${build.test.dir}/results">
+        <fileset dir="${src.test.dir}">
+          <include name="**/*Test*.java"/>
+        </fileset>
+      </batchtest>
     </junit>
   </target>
 

--- a/src/main/java/com/kenai/jffi/Init.java
+++ b/src/main/java/com/kenai/jffi/Init.java
@@ -129,7 +129,7 @@ final class Init {
     }
 
     private static UnsatisfiedLinkError newLoadError(Throwable cause) {
-        UnsatisfiedLinkError error = new UnsatisfiedLinkError();
+        UnsatisfiedLinkError error = new UnsatisfiedLinkError(cause.getLocalizedMessage());
         error.initCause(cause);
 
         return error;

--- a/src/test/java/com/kenai/jffi/ForeignTest.java
+++ b/src/test/java/com/kenai/jffi/ForeignTest.java
@@ -33,17 +33,6 @@ public class ForeignTest {
     public void tearDown() {
     }
 
-    // TODO add test methods here.
-    // The methods must be annotated with annotation @Test. For example:
-    //
-    // @Test
-    // public void hello() {}
-    @Test public void version() {
-        final int VERSION = Foreign.VERSION_MAJOR << 16 | Foreign.VERSION_MINOR << 8 | Foreign.VERSION_MICRO;
-        int version = Foreign.getInstance().getVersion();
-        assertEquals("Bad version", VERSION, version);
-    }
-
     @Test public void pageSize() {
         long pageSize = Foreign.getInstance().pageSize();
         assertNotSame("Invalid page size", 0, pageSize);

--- a/src/test/java/com/kenai/jffi/internal/StubLoaderTest.java
+++ b/src/test/java/com/kenai/jffi/internal/StubLoaderTest.java
@@ -9,9 +9,29 @@ import java.io.File;
 public class StubLoaderTest {
     @Test
     public void testExtractName() throws Throwable {
-        File path = StubLoader.calculateExtractPath(new File("foo"), "bar");
+        String barName = "bar";
+        String barFile = "bar." + StubLoader.dlExtension();
+
+        File path = StubLoader.calculateExtractPath(new File("foo"), barName);
 
         Assert.assertEquals("foo", path.getParent());
-        Assert.assertEquals("bar", path.getName());
+        Assert.assertEquals(barFile, path.getName());
+
+        path = StubLoader.calculateExtractPath(new File("foo"), barFile);
+
+        Assert.assertEquals("foo", path.getParent());
+        Assert.assertEquals(barFile, path.getName());
+    }
+
+    @Test
+    public void testDefaultExtractName() throws Throwable {
+        String defaultFile = "jffi-" + StubLoader.VERSION_MAJOR + "." + StubLoader.VERSION_MINOR + "." + StubLoader.dlExtension();
+
+        File path = StubLoader.calculateExtractPath(new File("foo"), "");
+
+        Assert.assertEquals("foo", path.getParent());
+        Assert.assertEquals(
+                defaultFile,
+                path.getName());
     }
 }

--- a/src/test/java/com/kenai/jffi/internal/StubLoaderTest.java
+++ b/src/test/java/com/kenai/jffi/internal/StubLoaderTest.java
@@ -1,0 +1,17 @@
+package com.kenai.jffi.internal;
+
+import com.kenai.jffi.internal.StubLoader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class StubLoaderTest {
+    @Test
+    public void testExtractName() throws Throwable {
+        File path = StubLoader.calculateExtractPath(new File("foo"), "bar");
+
+        Assert.assertEquals("foo", path.getParent());
+        Assert.assertEquals("bar", path.getName());
+    }
+}


### PR DESCRIPTION
Normally the library is extracted to a temp directory with an
appropriately-mangled temp name, but on platforms that cannot
delete the file before exiting the JVM this leaves those library
files to accumulate.

This change builds on the jffi.extract.dir property and adds
jffi.extract.name to specify a specific filename to use every
time, reusing any existing file at that location.

Depending on how these two properties are combined, the file will
be extracted as follows:

* Set neither: file will be extracted with a temp name under the
  default temp dir, with attempt to delete and no reuse.
* Set both: file will be the given name in the given path,
  reused if existing or extracted otherwise.
* Set only dir: file will be extracted with a temp name under the
  specified directory, with attempt to delete and no reuse.
* Set only name: file will be extracted with the given name under
  the default temp dir, reused if existing or extracted otherwise.

Note that this does not verify that the loaded file matches the
one bundled with jffi. This is left up to the user, since any
verification of the existing file will be subject to TOC-to-TOU
vulnerability. It is not possible to have the JVM atomically
verify and load the given file.

This partially addresses #97 by allowing Windows users to specify
a known file path to reuse across runs.