### PR TITLE
Reenable tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,41 +179,16 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.6</version>
-        <executions>
-          <execution>
-            <id>build-native-library</id>
-            <phase>process-classes</phase>
-            <configuration>
-              <tasks>
-                <property name="os.name" value="${os.name}" />
-                <property name="os.arch" value="${os.arch}" />
-                <property name="java.home" value="${java.home}" />
-                <property name="dist.dir" value="${project.build.directory}" />
-                <property name="build.dir" value="${project.build.directory}" />
-                <property name="build.classes.dir" value="${project.build.outputDirectory}" />
-                <ant antfile="build.xml" dir="." target="-assemble-native-jar" />
-                <unjar src="build/native.jar" dest="${project.build.outputDirectory}" />
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.6</version>
+          <version>3.0.0</version>
           <executions>
             <execution>
-            <id>build-native-library</id>
+            <id>generate-version</id>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <property name="os.name" value="${os.name}" />
                 <property name="os.arch" value="${os.arch}" />
                 <property name="java.home" value="${java.home}" />
@@ -221,39 +196,54 @@
                 <property name="build.dir" value="${project.build.directory}" />
                 <property name="build.classes.dir" value="${project.build.outputDirectory}" />
                 <ant antfile="version.xml" dir="." target="-generate-version-source" />
-              </tasks>
-              <sourceRoot>
-                ${project.build.directory}/java
-              </sourceRoot>
-
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>
             </goals>
           </execution>
             <execution>
-                <phase>process-test-resources</phase>
-                <goals>
-                    <goal>run</goal>
-                </goals>
-                <configuration>
-                    <tasks>
-                      <unzip dest="${project.build.directory}/" overwrite="true">
-                          <patternset>
-                            <include name="**/*.so" />
-                            <include name="**/*.dylib" />
-                            <include name="**/*.jnilib" />
-                            <include name="**/*.dll" />
-                            <include name="**/*.a" />
-                          </patternset>
-                          <fileset dir="archive">
-                            <include name="**/*.jar" />
-                          </fileset>
-                      </unzip>
-                    </tasks>
-                </configuration>
+              <id>build-native-library</id>
+              <phase>process-classes</phase>
+              <configuration>
+                <target>
+                  <property name="os.name" value="${os.name}"/>
+                  <property name="os.arch" value="${os.arch}"/>
+                  <property name="java.home" value="${java.home}"/>
+                  <property name="dist.dir" value="${project.build.directory}"/>
+                  <property name="build.dir" value="${project.build.directory}"/>
+                  <property name="build.classes.dir" value="${project.build.outputDirectory}"/>
+                  <ant antfile="build.xml" dir="." target="-assemble-native-jar"/>
+                  <unjar src="build/native.jar" dest="${project.build.outputDirectory}"/>
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
             </execution>
-        </executions>
+            <execution>
+              <phase>process-test-resources</phase>
+              <goals>
+                <goal>run</goal>
+              </goals>
+              <configuration>
+                <target>
+                  <unzip dest="${project.build.directory}/" overwrite="true">
+                    <patternset>
+                      <include name="**/*.so"/>
+                      <include name="**/*.dylib"/>
+                      <include name="**/*.jnilib"/>
+                      <include name="**/*.dll"/>
+                      <include name="**/*.a"/>
+                    </patternset>
+                    <fileset dir="archive">
+                      <include name="**/*.jar"/>
+                    </fileset>
+                  </unzip>
+                </target>
+              </configuration>
+            </execution>
+          </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,6 @@
   </dependencies>
 
   <properties>
-    <maven.test.skip>true</maven.test.skip>
-    <maven.test.failure.ignore>true</maven.test.failure.ignore>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
@@ -181,10 +179,9 @@
           </execution>
         </executions>
       </plugin>
-<!--
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.1</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>build-native-library</id>
@@ -197,8 +194,8 @@
                 <property name="dist.dir" value="${project.build.directory}" />
                 <property name="build.dir" value="${project.build.directory}" />
                 <property name="build.classes.dir" value="${project.build.outputDirectory}" />
-                <ant antfile="custom-build.xml" dir="." target="-assemble-native-jar" />
-                <unjar src="${project.build.directory}/native.jar" dest="${project.build.outputDirectory}" />
+                <ant antfile="build.xml" dir="." target="-assemble-native-jar" />
+                <unjar src="build/native.jar" dest="${project.build.outputDirectory}" />
               </tasks>
             </configuration>
             <goals>
@@ -207,7 +204,6 @@
           </execution>
         </executions>
       </plugin>
--->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
This was disabled over a decade ago, perhaps to avoid building the
native library for every mvn package. This is a first step to
getting these tests enabled, which would have prevented the
regression almost caused by naively fixing #93.