### PR TITLE
Add IBM i platform (and misc bugfixes)

### DIFF
--- a/jni/GNUmakefile
+++ b/jni/GNUmakefile
@@ -215,6 +215,20 @@ ifeq ($(OS), aix)
   JNIEXT = a
   STRIP = strip
 endif
+ifeq ($(OS), os400)
+  SOFLAGS = -shared -static-libgcc
+  CFLAGS += -pthread -D_CALL_ELF=0
+  LDFLAGS += -pthread
+  JNIEXT = so
+  STRIP = strip
+  LIBFFI = /QOpenSys/pkgs/lib/libffi.so
+  LIBFFI_LIBS ?= $(shell pkg-config --libs libffi)
+  LIBFFI_CFLAGS ?= $(shell pkg-config --cflags libffi)
+  PLATFORM = aix
+  MODEL = 64
+  ARCHES = ppc64
+  WFLAGS += -Werror=undef
+endif
 
 ifneq ($(OS), dragonflybsd)
   SOFLAGS = -shared
@@ -273,7 +287,7 @@ debug:
 	@echo "OBJS=$(OBJS)"
 
 $(LIBJFFI):  $(OBJS) $(LIBFFI_LIBS)
-	$(CC) -o $@ $(LDFLAGS) $(SOFLAGS) $(OBJS) $(LIBFFI_LIBS) $(LIBS)
+	$(CC) -o $@ $(LDFLAGS) $(SOFLAGS) $(OBJS) $(LIBFFI) $(LIBS)
 	$(STRIP) $@
 
 $(BUILD_DIR)/%.o : $(SRC_DIR)/%.c $(wildcard $(JFFI_SRC_DIR)/*.h)
@@ -284,7 +298,7 @@ $(BUILD_DIR)/%.o : $(SRC_DIR)/%.S $(wildcard $(JFFI_SRC_DIR)/*.h)
 	@mkdir -p $(@D)
 	@$(CC) $(CFLAGS) -o $@ -c $<
 
-$(OBJS) : $(LIBFFI_LIBS)
+$(OBJS) : $(LIBFFI)
 
 ifeq ($(OS), darwin)
 build_ffi = \

--- a/src/main/java/com/kenai/jffi/Platform.java
+++ b/src/main/java/com/kenai/jffi/Platform.java
@@ -55,8 +55,8 @@ public abstract class Platform {
         NETBSD,
         /** OpenBSD */
         OPENBSD,
-	/** DragonFly */
-	DRAGONFLY,
+        /** DragonFly */
+        DRAGONFLY,
         /** Linux */
         LINUX,
         /** Solaris (and OpenSolaris) */
@@ -65,6 +65,8 @@ public abstract class Platform {
         WINDOWS,
         /** IBM AIX */
         AIX,
+        /** IBM i */
+        IBMI,
         /** IBM zOS **/
         ZLINUX,
 
@@ -144,6 +146,9 @@ public abstract class Platform {
         } else if (startsWithIgnoreCase(osName, "aix")) {
             return OS.AIX; 
         
+        }else if (startsWithIgnoreCase(osName, "os/400") || startsWithIgnoreCase(osName, "os400")) {
+            return OS.IBMI;
+
         } else if (startsWithIgnoreCase(osName, "openbsd")) {
             return OS.OPENBSD;
         
@@ -367,6 +372,12 @@ public abstract class Platform {
         //
         if (libName.matches(getLibraryNamePattern())) {
             return libName;
+        }
+        //
+        // IBM i can return ".srvpgm" for legacy service programs, not supported by jffi
+        //
+        if (OS.IBMI.equals(getOS())) {
+            return "lib"+libName+".so";
         }
         return System.mapLibraryName(libName);
     }

--- a/src/main/java/com/kenai/jffi/internal/StubLoader.java
+++ b/src/main/java/com/kenai/jffi/internal/StubLoader.java
@@ -120,6 +120,8 @@ public class StubLoader {
         WINDOWS,
         /** IBM AIX */
         AIX,
+        /** IBM i */
+        IBMI,
         /** IBM zOS **/
         ZLINUX,
 
@@ -181,6 +183,8 @@ public class StubLoader {
             return OS.SOLARIS;
         } else if (Util.startsWithIgnoreCase(osName, "aix", LOCALE)) {
             return OS.AIX; 
+        } else if (Util.startsWithIgnoreCase(osName, "os400", LOCALE) || Util.startsWithIgnoreCase(osName, "os/400", LOCALE)) {
+            return OS.IBMI;
         } else if (Util.startsWithIgnoreCase(osName, "openbsd", LOCALE)) {
             return OS.OPENBSD;
         } else if (Util.startsWithIgnoreCase(osName, "freebsd", LOCALE)) {
@@ -275,7 +279,8 @@ public class StubLoader {
      * @return The path of the jar file.
      */
     private static String getStubLibraryPath() {
-        return "jni/" + getPlatformName() + "/"+ System.mapLibraryName(stubLibraryName);
+        String mappedLibraryName = OS.IBMI.equals(getOS()) ? ("lib" + stubLibraryName + ".so"): System.mapLibraryName(stubLibraryName);
+        return "jni/" + getPlatformName() + "/"+ mappedLibraryName;
     }
     
     public StubLoader() {}
@@ -426,7 +431,6 @@ public class StubLoader {
 
         try (InputStream sourceIS = getStubLibraryStream()) {
             dstFile = calculateExtractPath(tmpDirFile, jffiExtractName);
-
             if (jffiExtractName != null && dstFile.exists()) {
                 // unpacking to a specific name and that file exists, verify it
                 verifyExistingLibrary(dstFile, sourceIS);
@@ -499,7 +503,7 @@ public class StubLoader {
         File dstFile;
 
         // allow empty name to mean "jffi-#.#"
-        if (jffiExtractName.isEmpty()) {
+        if (null == jffiExtractName || jffiExtractName.isEmpty()) {
             jffiExtractName = "jffi-" + VERSION_MAJOR + "." + VERSION_MINOR;
         }
 


### PR DESCRIPTION
Adding IBM i platform
Some notes:
- For all intents and purposes, IBM i is always 64bit
- `System.mapLibraryName()` on IBM i is stupid (for compatibility reasons) and its return value is effectively junk
- On IBM i, system libffi must be used as IBM shipped a version without all patches upstreamed and the bundled version won't compile
- This PR includes two bugfixes not particularly related to IBM i, but encountered while porting the package. I can split them into a separate PR if needed:
   - Build referencing `LIBFFI_LIBS` (compile/link options) as build object
   - unset jffiExtractName variable in the StubLoader
   
Linking for reference https://github.com/jnr/jnr-ffi/issues/230 