### PR TITLE
Update to latest maven-ant-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,15 +226,34 @@
       </plugin>
 -->
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.2.0</version>
+          <executions>
+            <execution>
+              <id>add-source-directory</id>
+              <phase>generate-sources</phase>
+              <configuration>
+              <sources>
+                <source>${project.build.directory}/java</source>
+              </sources>
+              </configuration>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.6</version>
+          <version>3.0.0</version>
           <executions>
             <execution>
             <id>build-native-library</id>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <property name="os.name" value="${os.name}" />
                 <property name="os.arch" value="${os.arch}" />
                 <property name="java.home" value="${java.home}" />
@@ -242,11 +261,7 @@
                 <property name="build.dir" value="${project.build.directory}" />
                 <property name="build.classes.dir" value="${project.build.outputDirectory}" />
                 <ant antfile="version.xml" dir="." target="-generate-version-source" />
-              </tasks>
-              <sourceRoot>
-                ${project.build.directory}/java
-              </sourceRoot>
-
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>
@@ -258,7 +273,7 @@
                     <goal>run</goal>
                 </goals>
                 <configuration>
-                    <tasks>
+                    <target>
                       <unzip dest="${project.build.directory}/" overwrite="true">
                           <patternset>
                             <include name="**/*.so" />
@@ -271,7 +286,7 @@
                             <include name="**/*.jar" />
                           </fileset>
                       </unzip>
-                    </tasks>
+                    </target>
                 </configuration>
             </execution>
         </executions>


### PR DESCRIPTION
jffi uses some deprecated config options for the maven-antrun-plugin

These options are now removed in the latest version of antrun-plugin, so this change removes such usages. This allows jffi to move to the latest version of the antrun-plugin.

See the advice for moving to antrun-plugin 3.0.0 here: https://maven.apache.org/plugins/maven-antrun-plugin/
