### PR TITLE
Sign macOS binaries so that they work on Apple Silicon machines.

### DIFF
--- a/jni/GNUmakefile
+++ b/jni/GNUmakefile
@@ -280,6 +280,9 @@ debug:
 $(LIBJFFI):  $(OBJS) $(LIBFFI_LIBS)
 	$(CC) -o $@ $(LDFLAGS) $(SOFLAGS) $(OBJS) $(LIBFFI) $(LIBS)
 	$(STRIP) $@
+ifeq ($(OS), darwin)
+	codesign -s - $@
+endif
 
 $(BUILD_DIR)/%.o : $(SRC_DIR)/%.c $(wildcard $(JFFI_SRC_DIR)/*.h)
 	@mkdir -p $(@D)


### PR DESCRIPTION
Resolves https://github.com/jnr/jnr-ffi/issues/257.

An ad-hoc signature _seems_ to be sufficient based on reports from users in https://github.com/batect/batect/discussions/963.

Signature can be verified with `codesign -dv build/jni/libjffi-1.2.jnilib`.

