### PR TITLE
Fix tests on 32-bit ARM (armel and armhf), fix #130

### DIFF
--- a/jni/jffi/FastNumericInvoker.c
+++ b/jni/jffi/FastNumericInvoker.c
@@ -50,11 +50,7 @@
 
 
 /* for return values <= sizeof(long), need to use an ffi_sarg sized return value */
-#if BYTE_ORDER == BIG_ENDIAN
 # define RETVAL(retval, ctx) ((ctx->cif.rtype)->size > sizeof(ffi_sarg) ? (retval).j : (retval).sarg)
-#else
-# define RETVAL(retval, ctx) ((retval).j)
-#endif
 
 #define MAX_STACK_ARRAY (1024)
 

--- a/src/test/java/com/kenai/jffi/NumberTest.java
+++ b/src/test/java/com/kenai/jffi/NumberTest.java
@@ -264,6 +264,8 @@ public class NumberTest {
         Assume.assumeFalse("Apple Silicon does not support 80-bit long double",
                 Platform.getPlatform().getOS() == Platform.OS.DARWIN &&
                 Platform.getPlatform().getCPU() == Platform.CPU.AARCH64);
+        Assume.assumeFalse("32-bit ARM does not support 80-bit long double",
+                Platform.getPlatform().getCPU() == Platform.CPU.ARM);
         LibNumberTest lib = UnitHelper.loadTestLibrary(LibNumberTest.class, type);
         BigDecimal param = new BigDecimal("1.234567890123456789");
         BigDecimal result = lib.ret_f128(param);


### PR DESCRIPTION
With these two small fixes, the testsuite now passes on armel and armhf architectures.

Just to make sure, I tested this change on `amd64`, `arm64` and `ppc64el` and the testsuite remains passing on these architectures.