### PR TITLE
Add support for MIPS 32-bit little-endian architecture

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -83,6 +83,11 @@
         <os arch="loongarch64"/>
       </or>
     </condition>
+    <condition property="platform.cpu" value="mipsel">
+      <or>
+        <os arch="mipsel"/>
+      </or>
+    </condition>
     <condition property="platform.cpu" value="mips64">
       <or>
         <os arch="mips64"/>

--- a/jni/jffi/Foreign.c
+++ b/jni/jffi/Foreign.c
@@ -274,11 +274,14 @@ Java_com_kenai_jffi_Foreign_unregisterNatives(JNIEnv *env, jobject self, jclass 
 #elif defined(__ia64__) || defined(__ia64)
 # define CPU "ia64"
 
-#elif defined(__mips__) || defined(__mips) || defined(__mips64)
-# if defined (__mips64)
+#elif defined(__mips64)
+# if BYTE_ORDER == LITTLE_ENDIAN
 #  define CPU "mips64el"
-# else
-#  define CPU "mips"
+# endif
+
+#elif defined (__mips__) || defined (__mips)
+# if BYTE_ORDER == LITTLE_ENDIAN
+#  define CPU "mipsel"
 # endif
 
 #elif defined(__s390__)

--- a/src/main/java/com/kenai/jffi/Platform.java
+++ b/src/main/java/com/kenai/jffi/Platform.java
@@ -106,7 +106,9 @@ public abstract class Platform {
         AARCH64(64),
         /** LOONGARCH64 */
         LOONGARCH64(64),
-       /** MIPS64EL */
+        /** MIPSEL */
+        MIPSEL(32),
+        /** MIPS64EL */
         MIPS64EL(64),
         /** Unknown CPU */
         UNKNOWN(64);

--- a/src/main/java/com/kenai/jffi/internal/StubLoader.java
+++ b/src/main/java/com/kenai/jffi/internal/StubLoader.java
@@ -161,6 +161,8 @@ public class StubLoader {
         AARCH64,
         /** LOONGARCH64 */
         LOONGARCH64,
+        /** MIPS 32-bit little endian */
+        MIPSEL,
         /** MIPS 64-bit little endian */
         MIPS64EL,
         /** Unknown CPU */
@@ -231,6 +233,8 @@ public class StubLoader {
             return CPU.AARCH64;
         } else if (Util.equalsIgnoreCase("loongarch64", archString, LOCALE)) {
             return CPU.LOONGARCH64;
+        } else if (Util.equalsIgnoreCase("mipsel", archString, LOCALE)) {
+            return CPU.MIPSEL;
         } else if (Util.equalsIgnoreCase("mips64", archString, LOCALE) || Util.equalsIgnoreCase("mips64el", archString, LOCALE)) {
             return CPU.MIPS64EL;
 

--- a/src/test/java/com/kenai/jffi/NumberTest.java
+++ b/src/test/java/com/kenai/jffi/NumberTest.java
@@ -264,8 +264,9 @@ public class NumberTest {
         Assume.assumeFalse("Apple Silicon does not support 80-bit long double",
                 Platform.getPlatform().getOS() == Platform.OS.DARWIN &&
                 Platform.getPlatform().getCPU() == Platform.CPU.AARCH64);
-        Assume.assumeFalse("32-bit ARM does not support 80-bit long double",
-                Platform.getPlatform().getCPU() == Platform.CPU.ARM);
+        Assume.assumeFalse("32-bit ARM and MIPSel do not support 80-bit long double",
+                Platform.getPlatform().getCPU() == Platform.CPU.ARM ||
+                Platform.getPlatform().getCPU() == Platform.CPU.MIPSEL);
         LibNumberTest lib = UnitHelper.loadTestLibrary(LibNumberTest.class, type);
         BigDecimal param = new BigDecimal("1.234567890123456789");
         BigDecimal result = lib.ret_f128(param);


### PR DESCRIPTION
This adds support for the `mipsel` architecture. I tested the patch on both `mipsel` and `mips64el`.