### PR TITLE
Fix native artifact linking, fixes #128

### DIFF
--- a/jni/GNUmakefile
+++ b/jni/GNUmakefile
@@ -278,7 +278,7 @@ debug:
 	@echo "OBJS=$(OBJS)"
 
 $(LIBJFFI):  $(OBJS) $(LIBFFI_LIBS)
-	$(CC) -o $@ $(LDFLAGS) $(SOFLAGS) $(OBJS) $(LIBFFI) $(LIBS)
+	$(CC) -o $@ $(LDFLAGS) $(SOFLAGS) $(OBJS) $(LIBFFI_LIBS) $(LIBS)
 	$(STRIP) $@
 ifeq ($(OS), darwin)
 	codesign -s - $@
@@ -292,7 +292,7 @@ $(BUILD_DIR)/%.o : $(SRC_DIR)/%.S $(wildcard $(JFFI_SRC_DIR)/*.h)
 	@mkdir -p $(@D)
 	@$(CC) $(CFLAGS) -o $@ -c $<
 
-$(OBJS) : $(LIBFFI)
+$(OBJS) : $(LIBFFI_LIBS)
 
 ifeq ($(OS), darwin)
 build_ffi = \


### PR DESCRIPTION
This fixes linking of the native library to ffi, at least where we build against the system library.

The issue seems to have been introduced in 3a5a67790a16e32594ab33ae1260ed86a71242f3