### PR TITLE
Add support for riscv64

### DIFF
--- a/src/main/java/com/kenai/jffi/Platform.java
+++ b/src/main/java/com/kenai/jffi/Platform.java
@@ -110,6 +110,8 @@ public abstract class Platform {
         MIPSEL(32),
         /** MIPS64EL */
         MIPS64EL(64),
+        /** RISCV64 */
+        RISCV64(64),
         /** Unknown CPU */
         UNKNOWN(64);
 
@@ -255,6 +257,9 @@ public abstract class Platform {
 
             } else if (Util.equalsIgnoreCase("mips64", archString, LOCALE) || Util.equalsIgnoreCase("mips64el", archString, LOCALE)) {
                 return CPU.MIPS64EL;
+
+            } else if (Util.equalsIgnoreCase("riscv64", archString, LOCALE)) {
+                return CPU.RISCV64;
             }
             
 

--- a/src/main/java/com/kenai/jffi/internal/StubLoader.java
+++ b/src/main/java/com/kenai/jffi/internal/StubLoader.java
@@ -165,6 +165,8 @@ public class StubLoader {
         MIPSEL,
         /** MIPS 64-bit little endian */
         MIPS64EL,
+        /** RISC-V 64-bit little endian */
+        RISCV64,
         /** Unknown CPU */
         UNKNOWN;
 
@@ -237,6 +239,8 @@ public class StubLoader {
             return CPU.MIPSEL;
         } else if (Util.equalsIgnoreCase("mips64", archString, LOCALE) || Util.equalsIgnoreCase("mips64el", archString, LOCALE)) {
             return CPU.MIPS64EL;
+        } else if (Util.equalsIgnoreCase("riscv64", archString, LOCALE)) {
+            return CPU.RISCV64;
 
         }
 


### PR DESCRIPTION
Adds support for the RISC-V 64-bit architecture. Patch [contributed](https://sources.debian.org/src/jffi/1.3.9%2Bds-5/debian/patches/0013-Add-support-for-riscv64.patch/) via Debian.