### PR TITLE
Try using debian:8 for older glibc

### DIFF
--- a/.github/workflows/native-linux.yml
+++ b/.github/workflows/native-linux.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Restart Docker
         run: sudo systemctl restart docker.service
       - name: Pull docker image
-        run: docker pull --platform $(echo ${{ matrix.arch }} | sed 's|-|/|g') debian:10 || true
+        run: docker pull --platform $(echo ${{ matrix.arch }} | sed 's|-|/|g') debian:8 || true
       - name: Build inside Docker
         run: docker run --rm -v $GITHUB_WORKSPACE:/work debian:10 /work/.github/build-native-debian.sh
       - name: Archive built library


### PR DESCRIPTION
Building on debian:10 results in a binary that requires glibc 2.27 which is not available on some LTS server Linuxes like CentOS 7. This commit attempts to make a compatible jffi.so using debian:8, which ships with glibc 2.19. This is not as old as 2.17 but may remove enough dependencies on newer glibc to be sufficient.

See #138