### PR TITLE
Use cleaner instead of finalize

### DIFF
--- a/src/main/java/com/kenai/jffi/NativeMethods.java
+++ b/src/main/java/com/kenai/jffi/NativeMethods.java
@@ -32,7 +32,8 @@
 
 package com.kenai.jffi;
 
-import java.util.ArrayList;
+import com.kenai.jffi.internal.Cleaner;
+
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -144,18 +145,19 @@ public final class NativeMethods {
         public ResourceHolder(MemoryIO mm, long memory) {
             this.mm = mm;
             this.memory = memory;
-        }
-        
-        @Override
-        protected void finalize() throws Throwable {
-            try {
-                mm.freeMemory(memory);
-            } catch (Throwable t) {
-                Logger.getLogger(getClass().getName()).log(Level.WARNING, 
-                    "Exception when freeing native method struct array: %s", t.getLocalizedMessage());
-            } finally {
-                super.finalize();
-            }
+
+            Cleaner.register(this, new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        mm.freeMemory(memory);
+                    } catch (Throwable t) {
+                        Logger.getLogger(getClass().getName()).log(Level.WARNING,
+                                "Exception when freeing native method struct array: %s", t.getLocalizedMessage());
+                    }
+                }
+            });
         }
     }
+
 }

--- a/src/main/java/com/kenai/jffi/internal/Cleaner.java
+++ b/src/main/java/com/kenai/jffi/internal/Cleaner.java
@@ -1,0 +1,82 @@
+package com.kenai.jffi.internal;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public final class Cleaner {
+
+    private Cleaner() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static final Method createMethod;
+    private static final Method cleanMethod;
+    private static final Method registerMethod;
+    static {
+        Method method;
+        try {
+            method = Class.forName("java.lang.ref.Cleaner").getDeclaredMethod("register", Object.class, Runnable.class);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            method = null;
+        }
+        registerMethod = method;
+        if (registerMethod == null) {
+            try {
+                method = Class.forName("sun.misc.Cleaner").getDeclaredMethod("create", Object.class, Runnable.class);
+            } catch (NoSuchMethodException | ClassNotFoundException ignored) {
+            }
+            createMethod = method;
+            try {
+                method = Class.forName("java.lang.ref.Cleaner.Cleanable").getDeclaredMethod("clean");
+            } catch (ClassNotFoundException | NoSuchMethodException ignored) {
+            }
+            cleanMethod = method;
+        }
+        else {
+            try {
+                method = Class.forName("java.lang.ref.Cleaner").getDeclaredMethod("create");
+            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                method = null;
+            }
+            createMethod = method;
+            try {
+                method = Class.forName("sun.misc.Cleaner").getDeclaredMethod("clean");
+            } catch (NoSuchMethodException | ClassNotFoundException ex) {
+                method = null;
+            }
+            cleanMethod = method;
+        }
+    }
+
+    private static final Object cleanerLock = new Object();
+    private static volatile Object cleaner;
+
+    private static Object getCleaner(Object object, Runnable cleanProc) {
+        if (cleaner == null) synchronized (cleanerLock) {
+            if (cleaner == null) {
+                try {
+                    if (registerMethod == null) cleaner = createMethod.invoke(null, object, cleanProc);
+                    else cleaner = registerMethod.invoke(createMethod.invoke(null), object, cleanProc);
+                } catch (InvocationTargetException | IllegalAccessException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+        return cleaner;
+    }
+
+    public static Runnable register(Object object, Runnable cleanProc) {
+        Object cleaner = getCleaner(object, cleanProc);
+        return new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    cleanMethod.invoke(cleaner);
+                } catch (InvocationTargetException | IllegalAccessException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
As far as we know, the 'finalizer' mechanism of Java does not guarantee that `java.lang.Object#finalize()` will be called, that means release native resources in `finalize()` potentially cause a memory leak (I know in most cases this won't happen). But as a better solution, 'cleaner' may been used. For JDK 9 or later `java.lang.ref.Cleaner` could been used, for JDK 1.8 `sun.misc.Cleaner` is something potentially equivalent. I've made a simple compatible layer using JDK's reflection API, then made this PR.