### PR TITLE
Avoid locale-dependent String.format for numbers

### DIFF
--- a/src/main/java/com/kenai/jffi/internal/StubLoader.java
+++ b/src/main/java/com/kenai/jffi/internal/StubLoader.java
@@ -53,8 +53,7 @@ public class StubLoader {
     
     private static final String bootPropertyFilename = "boot.properties";
     private static final String bootLibraryPropertyName = "jffi.boot.library.path";
-    private static final String stubLibraryName
-            = String.format("jffi-%d.%d", VERSION_MAJOR, VERSION_MINOR);
+    private static final String stubLibraryName = "jffi-" + VERSION_MAJOR + '.' + VERSION_MINOR;
 
     private static final String TMPDIR_ENV =
             Platform.getPlatform().getOS() == Platform.OS.WINDOWS ?


### PR DESCRIPTION
Arabic numerals look like '١' instead of '1' and are used in some Arabic-speaking countries

String.format is locale-dependent, so it will produce these numbers, depending on the machine locale. This PR removes the use of String.format so that JFFI uses the correct string value for `stubLibraryName`.

### Sample Error

Without this PR, running JFFI using an Arabic locale produces an error like this:
```
[ERROR] : could not get native definition for type `POINTER`, original error message follows: java.lang.UnsatisfiedLinkError: could not locate stub library in jar file.  Tried [jni/x86_64-Linux/libjffi-١.٢.so, /jni/x86_64-Linux/libjffi-١.٢.so]
[ERROR] 	at com.kenai.jffi.internal.StubLoader.getStubLibraryStream(StubLoader.java:589)
[ERROR] 	at com.kenai.jffi.internal.StubLoader.loadFromJar(StubLoader.java:444)
[ERROR] 	at com.kenai.jffi.internal.StubLoader.load(StubLoader.java:338)
[ERROR] 	at com.kenai.jffi.internal.StubLoader.<clinit>(StubLoader.java:626)
```