### PR TITLE
feat: display GLIBC versions in GitHub Actions

### DIFF
--- a/.github/build-native-debian.sh
+++ b/.github/build-native-debian.sh
@@ -37,3 +37,5 @@ apt-get install -y --no-install-recommends ant
 rm archive/*
 ant jar && ant archive-platform-jar
 
+# 导出 GLIBC 依赖信息到 build/ 目录下，供外层 Action 使用
+objdump -p build/jni/*.so | grep GLIBC > build/glibc_versions.txt || true

--- a/.github/workflows/native-linux.yml
+++ b/.github/workflows/native-linux.yml
@@ -56,6 +56,14 @@ jobs:
         run: docker pull --platform $(echo ${{ matrix.arch }} | sed 's|-|/|g') "$DOCKER_IMAGE_NAME" || true
       - name: Build inside Docker
         run: docker run --rm -v $GITHUB_WORKSPACE:/work "$DOCKER_IMAGE_NAME" /work/.github/build-native-debian.sh
+      - name: Check GLIBC dependencies
+        run: |
+          docker run --rm -v $GITHUB_WORKSPACE:/work "$DOCKER_IMAGE_NAME" bash -c "objdump -p /work/build/jni/*.so | grep GLIBC || true" > glibc_versions.txt
+          echo "### GLIBC Dependencies for ${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat glibc_versions.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat glibc_versions.txt
       - name: Archive built library
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/native-linux.yml
+++ b/.github/workflows/native-linux.yml
@@ -58,12 +58,11 @@ jobs:
         run: docker run --rm -v $GITHUB_WORKSPACE:/work "$DOCKER_IMAGE_NAME" /work/.github/build-native-debian.sh
       - name: Check GLIBC dependencies
         run: |
-          docker run --rm -v $GITHUB_WORKSPACE:/work "$DOCKER_IMAGE_NAME" bash -c "objdump -p /work/build/jni/*.so | grep GLIBC || true" > glibc_versions.txt
           echo "### GLIBC Dependencies for ${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          cat glibc_versions.txt >> $GITHUB_STEP_SUMMARY
+          cat build/glibc_versions.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          cat glibc_versions.txt
+          cat build/glibc_versions.txt
       - name: Archive built library
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Follow-up to #183 

Updated the CI configuration to display the corresponding GLIBC versions for each artifacts directly in the GitHub Actions interface.

I'm not sure if this is the most elegant way to handle it. Do you have any suggestions for a better way to present or manage this version information?