### PR TITLE
Use a parent pom to ease management and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,8 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java-test-version }}
+    - name: Install dependencies on macOS
+      if: matrix.os == 'macos-latest'
+      run: brew install texinfo automake autoconf
     - name: Test
       run: ant test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         java-version: ['8', '11', '17', '21', '25']
+      fail-fast: false
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,32 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+
+  mvn-test-x86:
+
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        java-version: ['8', '11', '17', '21', '25']
+        os: [ubuntu-latest, macos-latest]
+        java-test-version: ['8', '11', '17', '21', '25']
       fail-fast: false
-
-    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17 for build
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v5
       with:
-        java-version: 17
+        distribution: 'zulu'
+        java-version: |
+          8
+          17
     - name: Build
       run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-    - name: Set up JDK ${{ matrix.java-version }} for test
-      uses: actions/setup-java@v1.4.3
+    - name: Set up JDK ${{ matrix.java-test-version }} for test
+      uses: actions/setup-java@v5
       with:
-        java-version: ${{ matrix.java-version }}
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-test-version }}
     - name: Test
       run: ant test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK ${{ matrix.java-version }}
+    - name: Set up JDK 17 for build
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: 17
+    - name: Build
+      run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+    - name: Set up JDK ${{ matrix.java-version }} for test
       uses: actions/setup-java@v1.4.3
       with:
         java-version: ${{ matrix.java-version }}
-    - name: Build
-      run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
     - name: Test
       run: ant test

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,20 @@
     </developer>
   </developers>
 
+  <repositories>
+    <repository>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,20 +41,6 @@
     </developer>
   </developers>
 
-  <repositories>
-    <repository>
-      <name>Central Portal Snapshots</name>
-      <id>central-portal-snapshots</id>
-      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
   <properties>
     <maven.test.skip>true</maven.test.skip>
     <maven.test.failure.ignore>true</maven.test.failure.ignore>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <make.exe>make</make.exe>
   </properties>
 
@@ -96,88 +95,41 @@
         <make.exe>gmake</make.exe>
       </properties>
     </profile>
-    <profile>
-      <id>java9</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <!-- Compile UnsafeMemoryIO without release flag, so it can access Unsafe -->
-                <id>default-compile</id>
-                <phase>compile</phase>
-                <configuration>
-                  <includes>
-                    <include>com/kenai/jffi/UnsafeMemoryIO.java</include>
-                  </includes>
-                </configuration>
-              </execution>
-              <execution>
-                <id>java9-compile</id>
-                <phase>compile</phase>
-                <goals><goal>compile</goal></goals>
-                <configuration>
-                  <!-- Compile the rest with release flag to ensure compatibility with 8 -->
-                  <!-- Use -release compiler option rather than source/target if 9+ -->
-                  <release>8</release>
-                  <!-- Exclude unsafe-using class when compiling with release flag -->
-                  <includes>
-                    <include>**/*.java</include>
-                  </includes>
-                  <excludes>
-                    <exclude>com/kenai/jffi/UnsafeMemoryIO.java</exclude>
-                  </excludes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.release>${java.specification.version}</maven.compiler.release>
-      </properties>
-    </profile>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-gpg-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-      <properties>
-        <invoker.skip>true</invoker.skip>
-      </properties>
-    </profile>
   </profiles>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <!-- This is a bit gross; we can't access sun.misc without jdk.supported, but we can't add jdk.unsupported
+             while also setting release 8. For now we require a JDK 8 toolchain to compile this one class. -->
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <jdkToolchain>
+                <version>8</version>
+              </jdkToolchain>
+              <includes>
+                <include>com/kenai/jffi/UnsafeMemoryIO.java</include>
+              </includes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>java9-compile</id>
+            <phase>compile</phase>
+            <goals><goal>compile</goal></goals>
+            <configuration>
+              <excludes>
+                <exclude>com/kenai/jffi/UnsafeMemoryIO.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
         <executions>
           <execution>
             <id>default-jar</id>
@@ -237,33 +189,6 @@
           </execution>
         </executions>
       </plugin>
-<!--
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.1</version>
-        <executions>
-          <execution>
-            <id>build-native-library</id>
-            <phase>process-classes</phase>
-            <configuration>
-              <tasks>
-                <property name="os.name" value="${os.name}" />
-                <property name="os.arch" value="${os.arch}" />
-                <property name="java.home" value="${java.home}" />
-                <property name="dist.dir" value="${project.build.directory}" />
-                <property name="build.dir" value="${project.build.directory}" />
-                <property name="build.classes.dir" value="${project.build.outputDirectory}" />
-                <ant antfile="custom-build.xml" dir="." target="-assemble-native-jar" />
-                <unjar src="${project.build.directory}/native.jar" dest="${project.build.outputDirectory}" />
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
--->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,6 @@
     <maven.test.skip>true</maven.test.skip>
     <maven.test.failure.ignore>true</maven.test.failure.ignore>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
     <make.exe>make</make.exe>
   </properties>
 
@@ -123,7 +121,7 @@
                 <configuration>
                   <!-- Compile the rest with release flag to ensure compatibility with 8 -->
                   <!-- Use -release compiler option rather than source/target if 9+ -->
-                  <release>${maven.compiler.target}</release>
+                  <release>8</release>
                   <!-- Exclude unsafe-using class when compiling with release flag -->
                   <includes>
                     <include>**/*.java</include>
@@ -140,6 +138,9 @@
       <activation>
         <jdk>[9,)</jdk>
       </activation>
+      <properties>
+        <maven.compiler.release>${java.specification.version}</maven.compiler.release>
+      </properties>
     </profile>
     <profile>
       <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,6 @@
     <groupId>com.github.jnr</groupId>
     <artifactId>jnr-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>jffi</artifactId>
@@ -180,7 +179,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.4.0</version>
         <extensions>false</extensions>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.jnr</groupId>
     <artifactId>jnr-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1</version>
   </parent>
 
   <artifactId>jffi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.github.jnr</groupId>
+
+  <parent>
+    <groupId>com.github.jnr</groupId>
+    <artifactId>jnr-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
   <artifactId>jffi</artifactId>
   <packaging>jar</packaging>
   <version>1.3.16-SNAPSHOT</version>
@@ -126,48 +133,7 @@
       <build>
         <plugins>
           <plugin>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <doclint>none</doclint>
-            </configuration>
-          </plugin>
-          <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.4</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <gpgArguments>
-                <gpgArgument>--pinentry-mode</gpgArgument>
-                <gpgArgument>loopback</gpgArgument>
-              </gpgArguments>
-            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -182,12 +148,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <debug>true</debug>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -384,15 +356,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.7.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <publishingServerId>central</publishingServerId>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The JNR projects have traditionally been released and managed separately, but they are very interconnected and frequently released at the same time. This PR moves to a common parent POM (managed in https://github.com/jnr/parent) to simplify plugin management and releasing.